### PR TITLE
Preliminary Windows support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,6 +19,15 @@ The simplest way to compile this package is:
   5. You can remove the program binaries and object files from [`src/`](src)
      and [`tools/`](tools) by typing `make clean` on the respective directory.
 
+## Steps for compiling libdft on Windows
+
+  1. Open a PowerShell console and run `install_pin.ps1` to download and install Pin.
+  2. Set `$PIN_ROOT` based on the output of the script.
+  3. Install [Chocolatery](https://chocolatey.org/): `Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))`
+  4. Install GNU Make for Windows: `choco install make`
+  5. `cd` to the directory [`src/`](src), which contains the source code of libdft,
+     and type `make` to compile the package (i.e., the libdft library)
+
 ## Supported platforms
 libdft has been successfully tested with:
 

--- a/install_pin.ps1
+++ b/install_pin.ps1
@@ -1,0 +1,12 @@
+if ($null -eq $PREFIX) {
+    $PREFIX=$HOME
+}
+
+$ZIP_NAME="pin-3.20-98437-gf02b61307-msvc-windows"
+
+Invoke-WebRequest -Uri "https://software.intel.com/sites/landingpage/pintool/downloads/${ZIP_NAME}.zip" -UseBasicParsing -OutFile "${ZIP_NAME}.zip"
+Expand-Archive -Path "${ZIP_NAME}.zip" -DestinationPath "${PREFIX}" -Force
+Remove-Item -Path "${ZIP_NAME}.zip"
+
+Write-Host "Please set:"
+Write-Host "`$PIN_ROOT=${PREFIX}\${ZIP_NAME}"

--- a/src/branch_pred.h
+++ b/src/branch_pred.h
@@ -34,7 +34,7 @@
 #define __BRANCH_PRED_H__
 
 /* compiler directives for branch prediction */
-#define likely(x)       __builtin_expect((x), 1)
-#define unlikely(x)     __builtin_expect((x), 0)
+#define likely(x)       __builtin_expect(!!(x), true)
+#define unlikely(x)     __builtin_expect(!!(x), false)
 
 #endif /* __BRANCH_PRED_H__ */

--- a/src/branch_pred.h
+++ b/src/branch_pred.h
@@ -34,7 +34,12 @@
 #define __BRANCH_PRED_H__
 
 /* compiler directives for branch prediction */
+#ifdef _WIN32
+#define likely(x)       (x)
+#define unlikely(x)     (x)
+#else
 #define likely(x)       __builtin_expect(!!(x), true)
 #define unlikely(x)     __builtin_expect(!!(x), false)
+#endif // _WIN32
 
 #endif /* __BRANCH_PRED_H__ */

--- a/src/libdft_api.cpp
+++ b/src/libdft_api.cpp
@@ -79,7 +79,7 @@ static void thread_alloc(THREADID tid, CONTEXT *ctx, INT32 flags, VOID *v) {
       free(tctx_prev);
 
       /* error message */
-      fprintf(stderr, "%s:%u", __func__, __LINE__);
+      fprintf(stderr, "%s:%s:%u\n", __FILE__, __func__, __LINE__);
 
       /* die */
       libdft_die();
@@ -110,7 +110,7 @@ static void sysenter_save(THREADID tid, CONTEXT *ctx, SYSCALL_STANDARD std,
   // LOGD("[syscall] %ld\n", syscall_nr);
   /* unknown syscall; optimized branch */
   if (unlikely(syscall_nr >= SYSCALL_MAX)) {
-    fprintf(stderr, "%s:%u: unknown syscall(num=%lu)", __func__, __LINE__,
+    fprintf(stderr, "%s:%s:%u: unknown syscall(num=%lu)\n", __FILE__, __func__, __LINE__,
             syscall_nr);
     /* syscall number is set to -1; hint for the sysexit_save() */
     threads_ctx[tid].syscall_ctx.nr = -1;
@@ -200,7 +200,7 @@ static void sysexit_save(THREADID tid, CONTEXT *ctx, SYSCALL_STANDARD std,
 
   /* unknown syscall; optimized branch */
   if (unlikely(syscall_nr < 0)) {
-    fprintf(stderr, "%s:%u: unknown syscall(num=%d)", __func__, __LINE__,
+    fprintf(stderr, "%s:%s:%u: unknown syscall(num=%d)\n", __FILE__, __func__, __LINE__,
             syscall_nr);
     /* no context save and no pre-syscall callback invocation */
     return;
@@ -329,7 +329,7 @@ static inline int thread_ctx_init(void) {
   threads_ctx = new thread_ctx_t[THREAD_CTX_BLK]();
 
   if (unlikely(threads_ctx == NULL)) {
-    fprintf(stderr, "%s:%u", __func__, __LINE__);
+    fprintf(stderr, "%s:%s:%u\n", __FILE__, __func__, __LINE__);
     /* failed */
     libdft_die();
     return 1;

--- a/src/syscall_desc.cpp
+++ b/src/syscall_desc.cpp
@@ -3,6 +3,7 @@
 #include "syscall_struct.h"
 #include "tagmap.h"
 
+#ifdef __linux__
 #include <sys/epoll.h>
 #include <sys/ioctl.h>
 #include <sys/ipc.h>
@@ -22,6 +23,7 @@
 #include <linux/kexec.h>
 #include <linux/mempolicy.h>
 #include <linux/sysctl.h>
+#endif // __linux__
 
 #include <err.h>
 #include <poll.h>
@@ -66,6 +68,7 @@ static void post_msgctl_hook(THREADID tid, syscall_ctx_t *ctx);
 
 /* syscall descriptors */
 syscall_desc_t syscall_desc[SYSCALL_MAX] = {
+#ifdef __linux__
     /* __NR_read = 0 */
     {3, 1, 0, {0, 0, 0, 0, 0, 0}, NULL, post_read_hook},
     /* __NR_write = 1 */
@@ -768,6 +771,7 @@ syscall_desc_t syscall_desc[SYSCALL_MAX] = {
     /* __NR_statx 332 */
     /* __NR_io_pgetevents 333 */
     /* __NR_rseq 334 */
+#endif // __linux__
 };
 
 /*
@@ -870,6 +874,7 @@ int syscall_clr_post(syscall_desc_t *desc) {
   return 0;
 }
 
+#ifdef __linux__
 /* __NR_(p)read(64) and __NR_readlink post syscall hook */
 static void post_read_hook(THREADID tid, syscall_ctx_t *ctx) {
   /* read()/readlink() was not successful; optimized branch */
@@ -1543,3 +1548,4 @@ static void post_recvmsg_hook(THREADID tid, syscall_ctx_t *ctx) {
     tot -= iov_tot;
   }
 }
+#endif // __linux__

--- a/src/tagmap.cpp
+++ b/src/tagmap.cpp
@@ -53,7 +53,11 @@ inline void tag_dir_setb(tag_dir_t &dir, ADDRINT addr, tag_t const &tag) {
   // LOG("Setting tag "+hexstr(addr)+"\n");
   if (dir.table[VIRT2PAGETABLE(addr)] == NULL) {
     //  LOG("No tag table for "+hexstr(addr)+" allocating new table\n");
+#ifndef _WIN32
     tag_table_t *new_table = new (std::nothrow) tag_table_t();
+#else // _WIN32
+    tag_table_t *new_table = new tag_table_t();
+#endif
     if (new_table == NULL) {
       LOG("Failed to allocate tag table!\n");
       libdft_die();
@@ -64,7 +68,11 @@ inline void tag_dir_setb(tag_dir_t &dir, ADDRINT addr, tag_t const &tag) {
   tag_table_t *table = dir.table[VIRT2PAGETABLE(addr)];
   if ((*table).page[VIRT2PAGE(addr)] == NULL) {
     //    LOG("No tag page for "+hexstr(addr)+" allocating new page\n");
+#ifndef _WIN32
     tag_page_t *new_page = new (std::nothrow) tag_page_t();
+#else // _WIN32
+    tag_page_t *new_page = new tag_page_t();
+#endif
     if (new_page == NULL) {
       LOG("Failed to allocate tag page!\n");
       libdft_die();


### PR DESCRIPTION
* Add Pin installation script for Windows
* `#ifdef` Linux-specific syscalls
* Update installation documentation.
* Update `tagmap.cpp` to avoid `std::nothrow` as it is not supported by the Pin CRT for Windows.

Current limitations:
* No Windows syscalls are implemented.
* Can only build the code under `src`, but not under `tools`.